### PR TITLE
Makefile: Add `.h` files as dependencies to all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,16 @@ INCLUDES += -I src/Backend/include -I ./
 SRC_FILES := $(wildcard $(addsuffix *.cpp, $(SRC_DIRS)))
 OBJS := $(SRC_FILES:%.cpp=$(BUILD_DIR)/%.o)
 
+# automatically create list of header files
+HEADERS := $(wildcard $(addsuffix *.h, $(INCLUDES)))
+
 # the actual makefile rules
 all: $(TARGET)
 
-$(TARGET): $(OBJS)
-	$(CXX) -o $@ $(LIBS) $(CXXFLAGS) $(INCLUDES) $^
+$(TARGET): $(OBJS) $(HEADERS)
+	$(CXX) -o $@ $(LIBS) $(CXXFLAGS) $(INCLUDES) $(OBJS)
 
-$(OBJS): $(BUILD_DIR)/%.o: %.cpp
+$(OBJS): $(BUILD_DIR)/%.o: %.cpp $(HEADERS)
 	mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c -o $@ $<
 


### PR DESCRIPTION
Scans all directories in the `INCLUDE` variable and looks for `.h` files. It adds these files as dependencies to all targets so they will be rebuilt if any of the `.h` files are modified. The downside to this approach is that if any of the `.h` files are modified, the entire project will be rebuilt. The alternative would be to manually specify what `.h` files each target needs.